### PR TITLE
Change String to Object in trackable Map type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## CHANGELOG
+### 1.1.20-SNAPSHOT
+- Trackable Map<String,String> second type changed to Object. (Map<String,Object>)
 
 ### 1.1.19-SNAPSHOT
 - tags type changed from int to String

--- a/README.MD
+++ b/README.MD
@@ -225,7 +225,7 @@ buildscript {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
   }
   dependencies {
-    classpath 'com.orhanobut.tracklytics:tracklytics-plugin:1.1.19-SNAPSHOT'
+    classpath 'com.orhanobut.tracklytics:tracklytics-plugin:1.1.20-SNAPSHOT'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.1.19-SNAPSHOT
+VERSION_NAME=1.1.20-SNAPSHOT
 GROUP=com.orhanobut.tracklytics
 
 POM_DESCRIPTION=Android analytics tracker

--- a/tracklytics-plugin/src/main/groovy/tracklytics/weaving/plugin/TracklyticsPlugin.groovy
+++ b/tracklytics-plugin/src/main/groovy/tracklytics/weaving/plugin/TracklyticsPlugin.groovy
@@ -28,7 +28,7 @@ class TracklyticsPlugin implements Plugin<Project> {
 
     project.dependencies {
       compile 'org.aspectj:aspectjrt:1.8.6'
-      compile 'com.orhanobut.tracklytics:tracklytics-runtime:1.1.19-SNAPSHOT@aar'
+      compile 'com.orhanobut.tracklytics:tracklytics-runtime:1.1.20-SNAPSHOT@aar'
     }
 
     variants.all { variant ->

--- a/tracklytics-runtime/src/main/java/com/orhanobut/tracklytics/Trackable.java
+++ b/tracklytics-runtime/src/main/java/com/orhanobut/tracklytics/Trackable.java
@@ -8,5 +8,5 @@ import java.util.Map;
  */
 public interface Trackable {
 
-  Map<String, String> getTrackableAttributes();
+  Map<String, Object> getTrackableAttributes();
 }

--- a/tracklytics-runtime/src/main/java/com/orhanobut/tracklytics/TrackerAspect.java
+++ b/tracklytics-runtime/src/main/java/com/orhanobut/tracklytics/TrackerAspect.java
@@ -255,7 +255,7 @@ public class TrackerAspect {
       if (annotation instanceof TrackableAttribute) {
         if (value instanceof Trackable) {
           Trackable trackable = (Trackable) value;
-          Map<String, String> trackableValues = trackable.getTrackableAttributes();
+          Map<String, Object> trackableValues = trackable.getTrackableAttributes();
           if (trackableValues != null) {
             attributes.putAll(trackable.getTrackableAttributes());
           }

--- a/tracklytics-runtime/src/test/java/com/orhanobut/tracklytics/TrackerAspectTest.java
+++ b/tracklytics-runtime/src/test/java/com/orhanobut/tracklytics/TrackerAspectTest.java
@@ -357,8 +357,8 @@ public class TrackerAspectTest {
   @Test public void testTrackable() throws Throwable {
     class Bar implements Trackable {
 
-      @Override public Map<String, String> getTrackableAttributes() {
-        Map<String, String> values = new HashMap<>();
+      @Override public Map<String, Object> getTrackableAttributes() {
+        Map<String, Object> values = new HashMap<>();
         values.put("key1", "value1");
         values.put("key2", "value2");
         return values;
@@ -386,7 +386,7 @@ public class TrackerAspectTest {
   @Test public void ignoreNullValuesOnTrackable() throws Throwable {
     class Bar implements Trackable {
 
-      @Override public Map<String, String> getTrackableAttributes() {
+      @Override public Map<String, Object> getTrackableAttributes() {
         return null;
       }
     }
@@ -604,8 +604,8 @@ public class TrackerAspectTest {
   @Test public void testTrackableAttributeForCurrentClass() throws Throwable {
     class Foo implements Trackable {
 
-      @Override public Map<String, String> getTrackableAttributes() {
-        Map<String, String> map = new HashMap<>();
+      @Override public Map<String, Object> getTrackableAttributes() {
+        Map<String, Object> map = new HashMap<>();
         map.put("key", "value");
         return map;
       }
@@ -631,8 +631,8 @@ public class TrackerAspectTest {
   @Test public void doNotUseTrackableAttributesWhenTrackableAttributeNotExists() throws Throwable {
     class Foo implements Trackable {
 
-      @Override public Map<String, String> getTrackableAttributes() {
-        Map<String, String> map = new HashMap<>();
+      @Override public Map<String, Object> getTrackableAttributes() {
+        Map<String, Object> map = new HashMap<>();
         map.put("key", "value");
         return map;
       }
@@ -656,7 +656,7 @@ public class TrackerAspectTest {
   @Test public void ignoreNullValueOnTrackableAttributeForCurrentClass() throws Throwable {
     class Foo implements Trackable {
 
-      @Override public Map<String, String> getTrackableAttributes() {
+      @Override public Map<String, Object> getTrackableAttributes() {
         return null;
       }
 


### PR DESCRIPTION
Currently getTrackables return Map<String,String>. It'll be more convenient to make the second type Object.